### PR TITLE
Bone ESP Attempt #2 + WorldToScreen

### DIFF
--- a/src/function_types.hpp
+++ b/src/function_types.hpp
@@ -28,6 +28,7 @@ namespace rage
 	class snMsgRemoveGamersFromSessionCmd;
 	class snSession;
 	class snPlayer;
+	class CViewPort;
 	class CDynamicEntity;
 	class netTimeSyncMsg;
 	class snConnectToPeerTaskData;

--- a/src/gta/matrix.hpp
+++ b/src/gta/matrix.hpp
@@ -23,7 +23,7 @@ namespace rage
 	class CViewPort
 	{
 	public:
-		char _0x0000[0x24C];
+		char _0x0000[0x27C];
 		float m_matrix[0x10];
 	};
 

--- a/src/gta_pointers.hpp
+++ b/src/gta_pointers.hpp
@@ -17,6 +17,7 @@ class CBlipList;
 class TimecycleKeyframeData;
 class CTrainConfig;
 class CWeaponInfoManager;
+class CViewPort;
 
 namespace rage
 {
@@ -124,6 +125,8 @@ namespace big
 		PVOID m_network_player_mgr_shutdown;
 
 		functions::get_gameplay_cam_coords m_get_gameplay_cam_coords;
+		
+		rage::CViewPort* m_viewport;
 
 		PVOID m_write_player_gamer_data_node;
 

--- a/src/pointers.cpp
+++ b/src/pointers.cpp
@@ -384,6 +384,15 @@ namespace big
                 g_pointers->m_gta.m_get_gameplay_cam_coords = ptr.sub(0xE).as<functions::get_gameplay_cam_coords>();
             }
         },
+        // Get Viewport
+        {
+			"GV",
+			"48 8B 15 ? ? ? ? 48 8D 2D ? ? ? ? 48 8B CD",
+            [](memory::handle ptr)
+            {
+                g_pointers->m_gta.m_viewport = ptr.add(3).as<rage::CViewPort*>();
+			}
+		},
         // Give Pickup Reward
         {
             "GPR",

--- a/src/views/esp/view_esp.cpp
+++ b/src/views/esp/view_esp.cpp
@@ -2,6 +2,7 @@
 
 #include "gta_util.hpp"
 #include "pointers.hpp"
+#include "gta/matrix.hpp"
 #include "services/players/player_service.hpp"
 #include "util/math.hpp"
 #include "util/misc.hpp"
@@ -36,7 +37,9 @@ namespace big
 
 		uint32_t ped_damage_bits = plyr->get_ped()->m_damage_bits;
 
-		if (g_pointers->m_gta.m_get_screen_coords_for_world_coords(player_pos.data, &screen_x, &screen_y))
+		Vector3 plyr_coords = {player_pos.x, player_pos.y, player_pos.z};
+		if (world_to_screen(plyr_coords, screen_x, screen_y))
+		//if (g_pointers->m_gta.m_get_screen_coords_for_world_coords(player_pos.data, &screen_x, &screen_y))
 		{
 			const auto esp_x = (float)*g_pointers->m_gta.m_resolution_x * screen_x;
 			const auto esp_y = (float)*g_pointers->m_gta.m_resolution_y * screen_y;
@@ -73,8 +76,78 @@ namespace big
 			{
 				// Map bone locations to x/y on screen
 				ImVec2 head_pos;
-				//bool head_valid = bone_to_screen(plyr, ePedBoneType::HEAD, head_pos);
+				bool head_valid = bone_to_screen(plyr, ePedBoneType::HEAD, head_pos);
+				if (head_valid)
+				{
+					// Draw circle around head
+					draw_list->AddCircle(head_pos, 20.f * multplr, esp_color, 0, 2.0f);
+				}
 
+				ImVec2 neck_pos;
+				bool neck_valid = bone_to_screen(plyr, ePedBoneType::NECK, neck_pos);
+				if (head_valid && neck_valid)
+				{
+					// Head to neck
+					draw_list->AddLine(head_pos, neck_pos, esp_color, 2.0f);
+				}
+
+				ImVec2 abdomen_pos;
+				bool abdomen_valid = bone_to_screen(plyr, ePedBoneType::ABDOMEN, abdomen_pos);
+				if (neck_valid && abdomen_valid)
+				{
+					// Neck to abdomen
+					draw_list->AddLine(neck_pos, abdomen_pos, esp_color, 2.0f);
+				}
+
+				ImVec2 l_hand_pos;
+				bool l_hand_valid = bone_to_screen(plyr, ePedBoneType::L_HAND, l_hand_pos);
+				if (neck_valid && l_hand_valid)
+				{
+					// Neck to left hand
+					draw_list->AddLine(neck_pos, l_hand_pos, esp_color, 2.0f);
+				}
+
+				ImVec2 r_hand_pos;
+				bool r_hand_valid = bone_to_screen(plyr, ePedBoneType::R_HAND, r_hand_pos);
+				if (neck_valid && r_hand_valid)
+				{
+					// Neck to right hand
+					draw_list->AddLine(neck_pos, r_hand_pos, esp_color, 2.0f);
+				}
+
+				ImVec2 l_ankle_pos;
+				bool l_ankle_valid = bone_to_screen(plyr, ePedBoneType::L_ANKLE, l_ankle_pos);
+				if (abdomen_valid && l_ankle_valid)
+				{
+					// Abdomen to left ankle
+					draw_list->AddLine(abdomen_pos, l_ankle_pos, esp_color, 2.0f);
+				}
+
+				ImVec2 r_ankle_pos;
+				bool r_ankle_valid = bone_to_screen(plyr, ePedBoneType::R_ANKLE, r_ankle_pos);
+				if (abdomen_valid && r_ankle_valid)
+				{
+					// Abdomen to right ankle
+					draw_list->AddLine(abdomen_pos, r_ankle_pos, esp_color, 2.0f);
+				}
+
+				ImVec2 l_foot_pos;
+				bool l_foot_valid = bone_to_screen(plyr, ePedBoneType::L_FOOT, l_foot_pos);
+				if (l_ankle_valid && l_foot_valid)
+				{
+					// Left ankle to left foot
+					draw_list->AddLine(l_ankle_pos, l_foot_pos, esp_color, 2.0f);
+				}
+
+				ImVec2 r_foot_pos;
+				bool r_foot_valid = bone_to_screen(plyr, ePedBoneType::R_FOOT, r_foot_pos);
+				if (r_ankle_valid && r_foot_valid)
+				{
+					// Right ankle to right foot
+					draw_list->AddLine(r_ankle_pos, r_foot_pos, esp_color, 2.0f);
+				}
+
+				/*
 				bool head_valid = bone_to_screen(plyr, (int)PedBones::SKEL_Head, head_pos);
 				
 				if (head_valid)
@@ -84,7 +157,7 @@ namespace big
 				}
 
 				// Make sure to validate both bones before drawing a line between them, otherwise off-screen bones will cause long lines across your screen
-				
+
 				ImVec2 neck_pos;
 				bool neck_valid = bone_to_screen(plyr, (int)PedBones::SKEL_Neck_1, neck_pos);
 
@@ -93,6 +166,7 @@ namespace big
 					// Head to neck
 					draw_list->AddLine(head_pos, neck_pos, esp_color, 2.0f);
 				}
+
 
 				ImVec2 r_shoulder_pos;
 				bool r_shoulder_valid = bone_to_screen(plyr, (int)PedBones::SKEL_R_Clavicle, r_shoulder_pos);
@@ -229,6 +303,7 @@ namespace big
 					// Left calf to left foot
 					draw_list->AddLine(l_calf_pos, l_foot_pos, esp_color, 2.0f);
 				}
+				*/
 			}
 
 			if (g.esp.name)
@@ -333,7 +408,7 @@ namespace big
 			}
 		}
 	}
-
+	/*
 	bool esp::bone_to_screen(const player_ptr& plyr, int boneID, ImVec2& boneVec)
 	{
 		bool isSuccess = false;
@@ -348,7 +423,6 @@ namespace big
 		float screenY = (float)*g_pointers->m_gta.m_resolution_y;
 
 		const auto player_ped = g_pointers->m_gta.m_ptr_to_handle(plyr->get_ped());
-
 		const auto bone_data = ENTITY::GET_WORLD_POSITION_OF_ENTITY_BONE(player_ped, PED::GET_PED_BONE_INDEX(player_ped, boneID));
 
 		float f_vec[3] = { bone_data.x, bone_data.y, bone_data.z };
@@ -358,6 +432,31 @@ namespace big
 		boneVec.y = screenY * bone_y;
 
 		return isSuccess;
+	}
+	*/
+
+	bool esp::bone_to_screen(const player_ptr& plyr, ePedBoneType boneType, ImVec2& boneVec)
+	{
+		if (plyr == nullptr)
+			return false;
+
+		float screenX = (float)*g_pointers->m_gta.m_resolution_x;
+		float screenY = (float)*g_pointers->m_gta.m_resolution_y;
+
+		// Validate stability of get_bone_coords
+		const auto player_bones = plyr->get_ped()->get_bone_coords(boneType);
+
+		Vector3 f_vec = {player_bones.x, player_bones.y, player_bones.z};
+
+		if (world_to_screen(f_vec, boneVec.x, boneVec.y))
+		{
+			boneVec.x = screenX * boneVec.x;
+			boneVec.y = screenY * boneVec.y;
+
+			return true;
+		}
+
+		return false;
 	}
 
 	void esp::draw()
@@ -374,4 +473,111 @@ namespace big
 			});
 		}
 	}
+
+    bool esp::world_to_screen(const Vector3 entity_position, float& screenX, float& screenY)
+    {
+        // Get the viewport matrix
+        rage::CViewPort* view_port = g_pointers->m_gta.m_viewport;
+
+        // Apply the transformation matrix to the entity position
+        Vector3 transformed_position;
+        transformed_position.x = view_port->m_matrix[1] * entity_position.x + view_port->m_matrix[5] * entity_position.y + view_port->m_matrix[9] * entity_position.z + view_port->m_matrix[13]; // Row 2
+        transformed_position.y = view_port->m_matrix[2] * entity_position.x + view_port->m_matrix[6] * entity_position.y + view_port->m_matrix[10] * entity_position.z + view_port->m_matrix[14]; // Row 3
+        transformed_position.z = view_port->m_matrix[3] * entity_position.x + view_port->m_matrix[7] * entity_position.y + view_port->m_matrix[11] * entity_position.z + view_port->m_matrix[15]; // Row 4
+
+        // Check if the transformed position is behind the camera
+        if (transformed_position.z < 0.001f)
+            return false;
+
+        // Perform perspective division
+        transformed_position.z = 1.0f / transformed_position.z;
+        transformed_position.x *= transformed_position.z;
+        transformed_position.y *= transformed_position.z;
+
+        // Get the resolution of the game window
+        float resolutionX = static_cast<float>(*g_pointers->m_gta.m_resolution_x);
+        float resolutionY = static_cast<float>(*g_pointers->m_gta.m_resolution_y);
+
+        // Calculate the screen coordinates
+        screenX = ((resolutionX * 0.5f) + (0.5f * transformed_position.x * resolutionX + 1.0f)) / resolutionX;
+        screenY = ((resolutionY * 0.5f) - (0.5f * transformed_position.y * resolutionY + 1.0f)) / resolutionY;
+
+        // Check if the screen coordinates are outside the screen boundaries
+        if (screenX > 1.0f || screenX < 0.0f || screenY > 1.0f || screenY < 0.0f)
+            return false;
+
+        return true;
+    }
+
+
+	/*
+
+
+	bool esp::world_to_screen(const Vector3 entity_position, float &screenX, float &screenY)
+	{
+		rage::CViewPort* view_port = g_pointers->m_gta.m_viewport;
+
+
+		// Viewport is a 16-element (4x4 matrix)
+		float cam_matrix[4][4] = {0};
+
+		// Copy the values from the 16-element viewport array to the 4x4 matrix
+		for (int i = 0; i < 16; i++)
+		{
+			cam_matrix[i / 4][i % 4] = view_port->m_matrix[i];
+		}
+
+		// LOG(INFO) << "cam_matrix: " << cam_matrix[0][0] << ", " << cam_matrix[0][1] << ", " << cam_matrix[0][2] << ", " << cam_matrix[0][3] << ", " << cam_matrix[1][0] << ", " << cam_matrix[1][1] << ", " << cam_matrix[1][2] << ", " << cam_matrix[1][3] << ", " << cam_matrix[2][0] << ", " << cam_matrix[2][1] << ", " << cam_matrix[2][2] << ", " << cam_matrix[2][3] << ", " << cam_matrix[3][0] << ", " << cam_matrix[3][1] << ", " << cam_matrix[3][2] << ", " << cam_matrix[3][3];
+
+		// Transpose
+		float transposed_cam_matrix[4][4] = {0};
+
+		for (int i = 0; i < 4; i++)
+		{
+			for (int j = 0; j < 4; j++)
+			{
+				transposed_cam_matrix[j][i] = cam_matrix[i][j];
+			}
+		}
+
+		Vector4 vecZ = {transposed_cam_matrix[3][0], transposed_cam_matrix[3][1], transposed_cam_matrix[3][2], transposed_cam_matrix[3][3]};
+		Vector4 vecX = {transposed_cam_matrix[1][0], transposed_cam_matrix[1][1], transposed_cam_matrix[1][2], transposed_cam_matrix[1][3]};
+		Vector4 vecY = {transposed_cam_matrix[2][0], transposed_cam_matrix[2][1], transposed_cam_matrix[2][2], transposed_cam_matrix[2][3]};
+
+		Vector3 screen_position = {0, 0, 0};
+		screen_position.z = (vecZ.x * entity_position.x) + (vecZ.y * entity_position.y) + (vecZ.z * entity_position.z) + vecZ.w;
+		screen_position.x =	(vecX.x * entity_position.x) + (vecX.y * entity_position.y) + (vecX.z * entity_position.z) + vecX.w;
+		screen_position.y = (vecY.x * entity_position.x) + (vecY.y * entity_position.y) + (vecY.z * entity_position.z) + vecY.w;
+
+		if (screen_position.z < 0.001f)
+		{
+			screenX = 0.0f;
+			screenY = 0.0f;
+			
+			return false;
+		}
+
+		float invw = 1.0f / screen_position.z;
+
+		screen_position.x *= invw;
+		screen_position.y *= invw;
+
+		LOG(INFO) << "screen_position: " << screen_position.x << ", " << screen_position.y;
+
+		float resX = (float)*g_pointers->m_gta.m_resolution_x;
+		float resY = (float)*g_pointers->m_gta.m_resolution_y;
+
+		// Compute res on-screen pixel position
+		screen_position.x += (resX / 2.0f) + (int)(0.5f * screen_position.x * resX + 0.5f);
+		screen_position.y = (resY / 2.0f) - (int)(0.5f * screen_position.y * resY + 0.5f);
+
+		screenX = screen_position.x;
+		screenY = screen_position.y;
+
+		LOG(INFO) << "screenX: " << screenX << ", screenY: " << screenY;
+
+		return true;
+	}*/
+
+
 }

--- a/src/views/esp/view_esp.hpp
+++ b/src/views/esp/view_esp.hpp
@@ -8,6 +8,8 @@ namespace big
 	public:
 		static void draw();
 		static void draw_player(const player_ptr& plyr, ImDrawList* const draw_list);
-		static bool bone_to_screen(const player_ptr& plyr, int boneID, ImVec2& boneVec);
+		//static bool bone_to_screen(const player_ptr& plyr, int boneID, ImVec2& boneVec);
+		static bool bone_to_screen(const player_ptr& plyr, ePedBoneType boneType, ImVec2& boneVec);
+		static bool world_to_screen(const Vector3 entity_position, float& screenX, float& screenY);
 	};
 }


### PR DESCRIPTION
This PR is for a new/reworked Bone ESP that calls a new implemented WorldToScreen function (credits to sub1to and his subVersion_2 menu). This improved stability on my system since m_get_screen_coords_for_world_coords was causing very frequent crashes, likely due to me calling it many times in a row for ped bones.

There may be still concerns in the community regarding get_bone_coords (see https://github.com/YimMenu/YimMenu/pull/2926#issuecomment-2041698458), so this code could use some additional testing on other systems to verify if it's still unstable or has been fixed. I have encountered no stability issues using get_bone_coords over at least 12 hours of playing across various lobbies. My headaches were solely caused by m_get_screen_coords_for_world_coords.

I have also reworked the existing Box ESP function to use the new WorldToScreen implementation and the result is functionally identical, though there may be some performance improvements since we're no longer calling GTA's own functions. No stability issues with the reworked Box ESP on my system, either.

WorldToScreen simply grabs the ViewPort which had to have its offset updated from 0x24C to 0x27C and required the addition of some helper functions (which has taught me a lot about how the menu is architected). The pattern has thankfully been unchanged for a few years, so it was easy to validate.

The WorldToScreen code is currently inside view_esp but can be (and probably should be) refactored into its own source file in the future since it can be useful in other areas, though the only place I see screen_coords_for_world_coords being used outside of ESP is in the context menu. If the code continues to be stable I may integrate it into an aimbot rework.